### PR TITLE
chore: Update cheqd testnet ID

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -247,7 +247,7 @@
       },
       {
         "name": "Testnet",
-        "chain_id": "cheqd-testnet-4",
+        "chain_id": "cheqd-testnet-6",
         "url": "https://testnet-explorer.cheqd.io"
       }
     ]


### PR DESCRIPTION
Update testnet ID from `cheqd-testnet-4` to `cheqd-testnet-6`